### PR TITLE
fix(seek): implement explicit async timeout

### DIFF
--- a/app/routers/seek.py
+++ b/app/routers/seek.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from langchain_ollama import ChatOllama
@@ -68,7 +70,14 @@ async def process_request(parameters: SeekParameters):
             timeout=parameters.timeout,
         )
         structured_model = model.with_structured_output(ContactList)
-        result = await structured_model.ainvoke(messages)
+        try:
+            async with asyncio.timeout(parameters.timeout):
+                result = await structured_model.ainvoke(messages)
+        except TimeoutError:
+            raise HTTPException(
+                status_code=504,
+                detail=f"Call timed out after {parameters.timeout} s",
+            )
 
         result_mongo = await mongodb.add_contact_details(
             contact_details=result,

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,5 +1,5 @@
 from langchain_ollama import ChatOllama
-
+import httpx
 from app.config import Settings
 
 settings = Settings()
@@ -39,5 +39,7 @@ def build_ollama_instance(
         repeat_penalty=repeat_penalty,
         # client_kwargs are given straight to httpx client
         # client_kwargs={"verify": False},  # uncomment if using private SSL cert
-        client_kwargs={"timeout": timeout},
+        client_kwargs={
+            "timeout": httpx.Timeout(60.0, connect=10.0, read=timeout, write=10.0)
+        },
     )


### PR DESCRIPTION
Timeout parameter passed to httpx via client_kwargs{...} didn't do what it was supposed to do, probably due to answer actually streaming in the background resetting the timeout counter constantly.

Asyncio.timeout implemented in this fix returns FastAPI HTTPError (504) if result didn't complete inside timeout limit.